### PR TITLE
fix negative rate metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.4.0 (2022-05-09)
+### Fixed
+- Use `prate` for metrics that report `*.PerSecond` stats. This prevents that metrics have negative values which is unexpected for this kind of metric.
+- Use `prate` for metrics that are reported as counters (accumulators) by the service. This prevent the metric has negative values if the counter resets.
+### Changed
+- bump dependencies:
+    `github.com/mitchellh/mapstructure v1.5.0`
+	`github.com/newrelic/infra-integrations-sdk v3.7.2+incompatible`
+	`github.com/stretchr/testify v1.7.1`
+- change pipeline to compile with Go 1.18
+
 ## 2.3.2 (2021-10-20)
 ### Added
 Added support for more distributions:

--- a/src/definitions.go
+++ b/src/definitions.go
@@ -4,27 +4,27 @@ package main
 type GeneralStats struct {
 	Bytes                  *int     `mapstructure:"bytes"                 metric_name:"bytesUsedServerInBytes"            source_type:"gauge"`
 	CurrItems              *int     `mapstructure:"curr_items"            metric_name:"currentItemsStoredServer"          source_type:"gauge"`
-	TotalItems             *int     `mapstructure:"total_items"           metric_name:"itemsStoredPerSecond"              source_type:"rate"`
+	TotalItems             *int     `mapstructure:"total_items"           metric_name:"itemsStoredPerSecond"              source_type:"prate"`
 	AverageItemSize        *float64 `                                     metric_name:"avgItemSizeInBytes"                source_type:"gauge"`
 	LimitMaxbytes          *int     `mapstructure:"limit_maxbytes"        metric_name:"limitBytesStorage"                 source_type:"gauge"`
 	PercentMaxUsed         *float64 `                                     metric_name:"storingItemsPercentMemory"         source_type:"gauge"`
-	BytesRead              *int     `mapstructure:"bytes_read"            metric_name:"bytesReadServerPerSecond"          source_type:"rate"`
-	BytesWritten           *int     `mapstructure:"bytes_written"         metric_name:"bytesWrittenServerPerSecond"       source_type:"rate"`
-	DeleteHits             *int     `mapstructure:"delete_hits"           metric_name:"deleteCmdRemovedPerSecond"         source_type:"rate"`
-	DeleteMisses           *int     `mapstructure:"delete_misses"         metric_name:"deleteCmdNoneRemovedPerSecond"     source_type:"rate"`
+	BytesRead              *int     `mapstructure:"bytes_read"            metric_name:"bytesReadServerPerSecond"          source_type:"prate"`
+	BytesWritten           *int     `mapstructure:"bytes_written"         metric_name:"bytesWrittenServerPerSecond"       source_type:"prate"`
+	DeleteHits             *int     `mapstructure:"delete_hits"           metric_name:"deleteCmdRemovedPerSecond"         source_type:"prate"`
+	DeleteMisses           *int     `mapstructure:"delete_misses"         metric_name:"deleteCmdNoneRemovedPerSecond"     source_type:"prate"`
 	TimeInListenDisabledUs *int     `mapstructure:"time_in_listen_disabled_us"`
 	ExpiredUnfetched       *int     `mapstructure:"expired_unfetched"`
-	CasBadval              *int     `mapstructure:"cas_badval"            metric_name:"casWrongRatePerSecond"             source_type:"rate"`
-	CasMisses              *int     `mapstructure:"cas_misses"            metric_name:"casMissRatePerSecond"              source_type:"rate"`
-	CasHits                *int     `mapstructure:"cas_hits"              metric_name:"casHitRatePerSecond"               source_type:"rate"`
-	GetHits                *int     `mapstructure:"get_hits"              metric_name:"getHitPerSecond"                   source_type:"rate"`
-	GetMisses              *int     `mapstructure:"get_misses"            metric_name:"getMissPerSecond"                  source_type:"rate"`
+	CasBadval              *int     `mapstructure:"cas_badval"            metric_name:"casWrongRatePerSecond"             source_type:"prate"`
+	CasMisses              *int     `mapstructure:"cas_misses"            metric_name:"casMissRatePerSecond"              source_type:"prate"`
+	CasHits                *int     `mapstructure:"cas_hits"              metric_name:"casHitRatePerSecond"               source_type:"prate"`
+	GetHits                *int     `mapstructure:"get_hits"              metric_name:"getHitPerSecond"                   source_type:"prate"`
+	GetMisses              *int     `mapstructure:"get_misses"            metric_name:"getMissPerSecond"                  source_type:"prate"`
 	GetExpired             *int     `mapstructure:"get_expired"`
 	GetFlushed             *int     `mapstructure:"get_flushed"`
 	GetHitPercent          *float64 `                                     metric_name:"getHitPercent"                     source_type:"gauge"`
-	CmdGet                 *int     `mapstructure:"cmd_get"               metric_name:"cmdGetRatePerSecond"               source_type:"rate"`
-	CmdSet                 *int     `mapstructure:"cmd_set"               metric_name:"cmdSetRatePerSecond"               source_type:"rate"`
-	CmdFlush               *int     `mapstructure:"cmd_flush"             metric_name:"cmdFlushRatePerSecond"             source_type:"rate"`
+	CmdGet                 *int     `mapstructure:"cmd_get"               metric_name:"cmdGetRatePerSecond"               source_type:"prate"`
+	CmdSet                 *int     `mapstructure:"cmd_set"               metric_name:"cmdSetRatePerSecond"               source_type:"prate"`
+	CmdFlush               *int     `mapstructure:"cmd_flush"             metric_name:"cmdFlushRatePerSecond"             source_type:"prate"`
 	CmdTouch               *int     `mapstructure:"cmd_touch"`
 	TouchHits              *int     `mapstructure:"touch_hits"`
 	TouchMisses            *int     `mapstructure:"touch_misses"`
@@ -32,10 +32,12 @@ type GeneralStats struct {
 	HashPowerLevel         *int     `mapstructure:"hash_power_level"`
 	AcceptingConns         *int     `mapstructure:"accepting_conns"`
 	HashIsExpanding        *int     `mapstructure:"hash_is_expanding"`
-	Evictions              *int     `mapstructure:"evictions"             metric_name:"evictionsPerSecond"                source_type:"rate"`
+	Evictions              *int     `mapstructure:"evictions"             metric_name:"evictionsPerSecond"                source_type:"prate"`
 	EvictedUnfetched       *int     `mapstructure:"evicted_unfetched"`
 	ConnectionStructures   *int     `mapstructure:"connection_structures" metric_name:"connectionStructuresAllocated"     source_type:"gauge"`
 	CurrConnections        *int     `mapstructure:"curr_connections"      metric_name:"openConnectionsServer"             source_type:"gauge"`
+	TotalConnections       *int     `mapstructure:"total_connections"     metric_name:"connectionRateServerPerSecond"     source_type:"prate"`
+	ConnYields             *int     `mapstructure:"conn_yields"           metric_name:"serverMaxConnectionLimitPerSecond" source_type:"prate"`
 	RusageUser             *float64 `mapstructure:"rusage_user"           metric_name:"executionTime"                     source_type:"prate"`
 	RusageSystem           *float64 `mapstructure:"rusage_system"         metric_name:"usageRate"                         source_type:"prate"`
 	PID                    *int     `mapstructure:"pid"`
@@ -68,46 +70,46 @@ type GeneralStats struct {
 // ItemStats is a struct which is used to marshal metrics into a metric set
 type ItemStats struct {
 	EvictedTime         *int `mapstructure:"evicted_time"      metric_name:"itemsTimeSinceEvictionInMilliseconds"       source_type:"gauge"`
-	Evicted             *int `mapstructure:"evicted"           metric_name:"evictionsBeforeExpirationPerSecond"         source_type:"rate"`
-	EvictedNonzero      *int `mapstructure:"evicted_nonzero"   metric_name:"evictionsBeforeExplicitExpirationPerSecond" source_type:"rate"`
-	ExpiredUnfetched    *int `mapstructure:"expired_unfetched" metric_name:"validItemsEvictedPerSecond"                 source_type:"rate"`
-	EvictedUnfetched    *int `mapstructure:"evicted_unfetched" metric_name:"expiredItemsReclaimedPerSecond"             source_type:"rate"`
-	OutOfMemory         *int `mapstructure:"outofmemory"       metric_name:"outOfMemoryPerSecond"                       source_type:"rate"`
+	Evicted             *int `mapstructure:"evicted"           metric_name:"evictionsBeforeExpirationPerSecond"         source_type:"prate"`
+	EvictedNonzero      *int `mapstructure:"evicted_nonzero"   metric_name:"evictionsBeforeExplicitExpirationPerSecond" source_type:"prate"`
+	ExpiredUnfetched    *int `mapstructure:"expired_unfetched" metric_name:"validItemsEvictedPerSecond"                 source_type:"prate"`
+	EvictedUnfetched    *int `mapstructure:"evicted_unfetched" metric_name:"expiredItemsReclaimedPerSecond"             source_type:"prate"`
+	OutOfMemory         *int `mapstructure:"outofmemory"       metric_name:"outOfMemoryPerSecond"                       source_type:"prate"`
 	Number              *int `mapstructure:"number"            metric_name:"itemsSlabClass"                             source_type:"gauge"`
 	NumberHot           *int `mapstructure:"number_hot"        metric_name:"itemsHot"                                   source_type:"gauge"`
 	NumberCold          *int `mapstructure:"number_cold"       metric_name:"itemsCold"                                  source_type:"gauge"`
 	NumberWarm          *int `mapstructure:"number_warm"       metric_name:"itemsWarm"                                  source_type:"gauge"`
-	TailRepairs         *int `mapstructure:"tailrepairs"       metric_name:"selfHealedSlabPerSecond"                    source_type:"rate"`
-	CrawlerReclaimed    *int `mapstructure:"crawler_reclaimed" metric_name:"itemsFreedCrawlerPerSecond"                 source_type:"rate"`
+	TailRepairs         *int `mapstructure:"tailrepairs"       metric_name:"selfHealedSlabPerSecond"                    source_type:"prate"`
+	CrawlerReclaimed    *int `mapstructure:"crawler_reclaimed" metric_name:"itemsFreedCrawlerPerSecond"                 source_type:"prate"`
 	CrawlerItemsChecked *int `mapstructure:"crawler_items_checked"`
-	Reclaimed           *int `mapstructure:"reclaimed"         metric_name:"entriesReclaimedPerSecond"                  source_type:"rate"`
-	LrutailReflocked    *int `mapstructure:"lrutail_reflocked" metric_name:"itemsRefcountLockedPerSecond"               source_type:"rate"`
+	Reclaimed           *int `mapstructure:"reclaimed"         metric_name:"entriesReclaimedPerSecond"                  source_type:"prate"`
+	LrutailReflocked    *int `mapstructure:"lrutail_reflocked" metric_name:"itemsRefcountLockedPerSecond"               source_type:"prate"`
 	Age                 *int `mapstructure:"age"               metric_name:"itemsOldestInMilliseconds"                  source_type:"gauge"`
-	DirectReclaims      *int `mapstructure:"direct_reclaims"   metric_name:"itemsDirectReclaimedPerSecond"              source_type:"rate"`
-	MovesToCold         *int `mapstructure:"moves_to_cold"     metric_name:"itemsColdPerSecond"                         source_type:"rate"`
-	MovesToWarm         *int `mapstructure:"moves_to_warm"     metric_name:"itemsWarmPerSecond"                         source_type:"rate"`
-	MovesWithinLRU      *int `mapstructure:"moves_within_lru"  metric_name:"activeItemsBumpedPerSecond"                 source_type:"rate"`
+	DirectReclaims      *int `mapstructure:"direct_reclaims"   metric_name:"itemsDirectReclaimedPerSecond"              source_type:"prate"`
+	MovesToCold         *int `mapstructure:"moves_to_cold"     metric_name:"itemsColdPerSecond"                         source_type:"prate"`
+	MovesToWarm         *int `mapstructure:"moves_to_warm"     metric_name:"itemsWarmPerSecond"                         source_type:"prate"`
+	MovesWithinLRU      *int `mapstructure:"moves_within_lru"  metric_name:"activeItemsBumpedPerSecond"                 source_type:"prate"`
 }
 
 // SlabStats is a struct which is used to marshal metrics into a metric set
 type SlabStats struct {
-	GetHits             *int `mapstructure:"get_hits"        metric_name:"getHitRateSlabPerSecond"          source_type:"rate"`
-	CmdSet              *int `mapstructure:"cmd_set"         metric_name:"cmdSetRateSlabPerSecond"          source_type:"rate"`
-	DeleteHits          *int `mapstructure:"delete_hits"     metric_name:"deleteRateSlabPerSecond"          source_type:"rate"`
-	IncrHits            *int `mapstructure:"incr_hits"       metric_name:"incrsModifySlabPerSecond"         source_type:"rate"`
-	DecrHits            *int `mapstructure:"decr_hits"       metric_name:"decrsModifySlabPerSecond"         source_type:"rate"`
-	CasHits             *int `mapstructure:"cas_hits"        metric_name:"casModifiedSlabPerSecond"         source_type:"rate"`
-	CasBadval           *int `mapstructure:"cas_badval"      metric_name:"casBadValPerSecond"               source_type:"rate"`
-	TouchHits           *int `mapstructure:"touch_hits"      metric_name:"touchHitSlabPerSecond"            source_type:"rate"`
+	GetHits             *int `mapstructure:"get_hits"        metric_name:"getHitRateSlabPerSecond"          source_type:"prate"`
+	CmdSet              *int `mapstructure:"cmd_set"         metric_name:"cmdSetRateSlabPerSecond"          source_type:"prate"`
+	DeleteHits          *int `mapstructure:"delete_hits"     metric_name:"deleteRateSlabPerSecond"          source_type:"prate"`
+	IncrHits            *int `mapstructure:"incr_hits"       metric_name:"incrsModifySlabPerSecond"         source_type:"prate"`
+	DecrHits            *int `mapstructure:"decr_hits"       metric_name:"decrsModifySlabPerSecond"         source_type:"prate"`
+	CasHits             *int `mapstructure:"cas_hits"        metric_name:"casModifiedSlabPerSecond"         source_type:"prate"`
+	CasBadval           *int `mapstructure:"cas_badval"      metric_name:"casBadValPerSecond"               source_type:"prate"`
+	TouchHits           *int `mapstructure:"touch_hits"      metric_name:"touchHitSlabPerSecond"            source_type:"prate"`
 	UsedChunks          *int `mapstructure:"used_chunks"     metric_name:"usedChunksItems"                  source_type:"gauge"`
-	UsedChunksPerSecond *int `mapstructure:"used_chunks"     metric_name:"usedChunksPerSecond"              source_type:"rate"`
+	UsedChunksPerSecond *int `mapstructure:"used_chunks"     metric_name:"usedChunksPerSecond"              source_type:"prate"`
 	ChunkSize           *int `mapstructure:"chunk_size"      metric_name:"chunkSizeInBytes"                 source_type:"gauge"`
 	ChunksPerPage       *int `mapstructure:"chunks_per_page" metric_name:"chunksPerPage"                    source_type:"gauge"`
 	TotalPages          *int `mapstructure:"total_pages"     metric_name:"totalPagesSlab"                   source_type:"gauge"`
 	TotalChunks         *int `mapstructure:"total_chunks"    metric_name:"totalChunksSlab"                  source_type:"gauge"`
 	FreeChunks          *int `mapstructure:"free_chunks"     metric_name:"freedChunks"                      source_type:"gauge"`
 	FreeChunksEnd       *int `mapstructure:"free_chunks_end" metric_name:"freedChunksEnd"                   source_type:"gauge"`
-	MemRequested        *int `mapstructure:"mem_requested"   metric_name:"memRequestedSlabInBytesPerSecond" source_type:"rate"`
+	MemRequested        *int `mapstructure:"mem_requested"   metric_name:"memRequestedSlabInBytesPerSecond" source_type:"prate"`
 }
 
 // ClusterSlabStats is a struct which is used to marshal metrics into a metric set

--- a/src/definitions.go
+++ b/src/definitions.go
@@ -36,10 +36,8 @@ type GeneralStats struct {
 	EvictedUnfetched       *int     `mapstructure:"evicted_unfetched"`
 	ConnectionStructures   *int     `mapstructure:"connection_structures" metric_name:"connectionStructuresAllocated"     source_type:"gauge"`
 	CurrConnections        *int     `mapstructure:"curr_connections"      metric_name:"openConnectionsServer"             source_type:"gauge"`
-	TotalConnections       *int     `mapstructure:"total_connections"     metric_name:"connectionRateServerPerSecond"     source_type:"rate"`
-	ConnYields             *int     `mapstructure:"conn_yields"           metric_name:"serverMaxConnectionLimitPerSecond" source_type:"rate"`
-	RusageUser             *float64 `mapstructure:"rusage_user"           metric_name:"executionTime"                     source_type:"rate"`
-	RusageSystem           *float64 `mapstructure:"rusage_system"         metric_name:"usageRate"                         source_type:"rate"`
+	RusageUser             *float64 `mapstructure:"rusage_user"           metric_name:"executionTime"                     source_type:"prate"`
+	RusageSystem           *float64 `mapstructure:"rusage_system"         metric_name:"usageRate"                         source_type:"prate"`
 	PID                    *int     `mapstructure:"pid"`
 	LogWatcherSkipped      *int     `mapstructure:"log_watcher_skipped"`
 	CrawlerItemsChecked    *int     `mapstructure:"crawler_items_checked"`


### PR DESCRIPTION
I checked that there are two kinds of metrics that uses `rate`. One group has the `PerSecond` suffix and the others which not. 

Even if the original metrics are counters (always increase type) or gauges (can have any value at any time). [Service docs.](https://github.com/memcached/memcached/blob/master/doc/protocol.txt)

This PR:
- Uses `prate` for all metrics that report `*.PerSecond` stats. This prevents that metrics have negative values which is unexpected for this kind of metric.
- Use `prate` for metrics that are reported as counters by the service. This prevent the metric has negative values if the counter get reseted.

Fixes #18