### PR TITLE
fix: upgrade go version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
+
+### security
+- update go to v1.25.9
 ## v2.8.0 - 2026-03-27
 
 ### 🛡️ Security notices

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/newrelic/nri-memcached
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/memcachier/mc v2.0.2-0.20181103130939-5d1620e2c6d8+incompatible

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     restart: always
 
   nri-memcached:
-    image: golang:1.25.8-bookworm
+    image: golang:1.25.9-bookworm
     container_name: nri-memcached
     working_dir: /code
     environment: 


### PR DESCRIPTION
## Summary
- Update Go to v1.25.9
- Run `go mod tidy` to update dependencies
- Update CHANGELOG.md with security entry

## Test plan
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)